### PR TITLE
Multithreading/avoid corruption

### DIFF
--- a/Expressmapper.Shared/MappingServiceProvider.cs
+++ b/Expressmapper.Shared/MappingServiceProvider.cs
@@ -300,9 +300,8 @@ namespace ExpressMapper
             var destType = typeof(TN);
             var cacheKey = CalculateCacheKey(srcType, destType);
 
-            if (CustomMappers.ContainsKey(cacheKey))
+            if (CustomMappers.TryGetValue(cacheKey, out var customTypeMapper))
             {
-                var customTypeMapper = CustomMappers[cacheKey];
                 var typeMapper = customTypeMapper() as ICustomTypeMapper<T, TN>;
                 var context = new DefaultMappingContext<T, TN> { Source = src, Destination = dest };
                 return typeMapper.Map(context);
@@ -390,9 +389,8 @@ namespace ExpressMapper
             }
 
             var cacheKey = CalculateCacheKey(srcType, dstType);
-            if (CustomMappers.ContainsKey(cacheKey))
+            if (CustomMappers.TryGetValue(cacheKey, out var customTypeMapper))
             {
-                var customTypeMapper = CustomMappers[cacheKey];
                 var typeMapper = customTypeMapper();
                 var exists = _customTypeMapperCache.TryGetValue(cacheKey, out var materializer);
                 if (!exists)
@@ -429,9 +427,8 @@ namespace ExpressMapper
             }
             else
             {
-                if (CustomMappingsBySource.ContainsKey(srcHash))
+                if (CustomMappingsBySource.TryGetValue(srcHash, out var mappings))
                 {
-                    var mappings = CustomMappingsBySource[srcHash];
                     var typeMappers =
                         mappings.Where(m => SourceService.TypeMappers.ContainsKey(m))
                             .Select(m => SourceService.TypeMappers[m])
@@ -460,9 +457,8 @@ namespace ExpressMapper
                 return nonGenericMapFunc(src, dest);
             }
 
-            if (mappingService.TypeMappers.ContainsKey(cacheKey))
+            if (mappingService.TypeMappers.TryGetValue(cacheKey, out mapper))
             {
-                mapper = mappingService.TypeMappers[cacheKey];
                 var nonGenericMapFunc = mapper.GetNonGenericMapFunc();
                 return nonGenericMapFunc(src, dest);
             }

--- a/Expressmapper.Shared/MappingServiceProvider.cs
+++ b/Expressmapper.Shared/MappingServiceProvider.cs
@@ -272,8 +272,7 @@ namespace ExpressMapper
 
                 var newExpression = Expression.New(typeof(TMapper));
                 var newLambda = Expression.Lambda<Func<ICustomTypeMapper<T, TN>>>(newExpression);
-                var compile = newLambda.Compile();
-                CustomMappers[cacheKey] = compile;
+                AddToDictionary(ref _customMappers, cacheKey, newLambda.Compile());
             }
         }
 

--- a/Expressmapper.Shared/MappingServiceProvider.cs
+++ b/Expressmapper.Shared/MappingServiceProvider.cs
@@ -415,10 +415,8 @@ namespace ExpressMapper
                 if (dstType != actualDstType && actualDstType.GetInfo().IsAssignableFrom(dstType))
                     throw new InvalidCastException($"Your destination object instance type '{actualSrcType.FullName}' is not assignable from destination type you specified '{srcType}'.");
 
-                if (CustomMappingsBySource.ContainsKey(srcHash))
+                if (CustomMappingsBySource.TryGetValue(srcHash, out var mappings))
                 {
-                    var mappings = CustomMappingsBySource[srcHash];
-
                     mapper =
                         mappings.Where(m => DestinationService.TypeMappers.ContainsKey(m))
                             .Select(m => DestinationService.TypeMappers[m])

--- a/Expressmapper.Shared/MappingServiceProvider.cs
+++ b/Expressmapper.Shared/MappingServiceProvider.cs
@@ -512,7 +512,7 @@ namespace ExpressMapper
             action();
         }
 
-        private void CompileNonGenericCustomTypeMapper(Type srcType, Type dstType, ICustomTypeMapper typeMapper, long cacheKey)
+        private Func<object, object, object> CompileNonGenericCustomTypeMapper(Type srcType, Type dstType, ICustomTypeMapper typeMapper, long cacheKey)
         {
             var sourceExpression = Expression.Parameter(typeof(object), "src");
             var destinationExpression = Expression.Parameter(typeof(object), "dst");
@@ -555,7 +555,11 @@ namespace ExpressMapper
                 srcAssigned, dstAssigned, assignExp, assignContextExp, sourceAssignedExp, destAssignedExp, /*destinationAssignedExp,*/ resultAssignExp, resultVarExp);
 
             var lambda = Expression.Lambda<Func<object, object, object>>(blockExpression, sourceExpression, destinationExpression);
-            _customTypeMapperCache[cacheKey] = lambda.Compile();
+            var result = lambda.Compile();
+
+            _customTypeMapperCache[cacheKey] = result;
+
+            return result;
         }
 
         internal static Type GetCollectionElementType(Type type)

--- a/Expressmapper.Shared/MappingServiceProvider.cs
+++ b/Expressmapper.Shared/MappingServiceProvider.cs
@@ -13,7 +13,9 @@ namespace ExpressMapper
     {
         private readonly object _lock = new object();
 
-        public Dictionary<long, Func<ICustomTypeMapper>> CustomMappers { get; set; }
+        private Dictionary<long, Func<ICustomTypeMapper>> _customMappers;
+        public Dictionary<long, Func<ICustomTypeMapper>> CustomMappers { get => _customMappers; set => _customMappers = value; }
+
         public Dictionary<int, IList<long>> CustomMappingsBySource { get; set; }
         private volatile Dictionary<long, Func<object, object, object>> _customTypeMapperCache = new Dictionary<long, Func<object, object, object>>();
         private readonly List<long> _nonGenericCollectionMappingCache = new List<long>();
@@ -39,7 +41,7 @@ namespace ExpressMapper
                 new SourceMappingService(this),
                 new DestinationMappingService(this)
             };
-            CustomMappers = new Dictionary<long, Func<ICustomTypeMapper>>();
+            _customMappers = new Dictionary<long, Func<ICustomTypeMapper>>();
             CustomMappingsBySource = new Dictionary<int, IList<long>>();
         }
 

--- a/Expressmapper.Shared/MappingServiceProvider.cs
+++ b/Expressmapper.Shared/MappingServiceProvider.cs
@@ -17,7 +17,7 @@ namespace ExpressMapper
         public Dictionary<long, Func<ICustomTypeMapper>> CustomMappers { get => _customMappers; set => _customMappers = value; }
 
         public Dictionary<int, IList<long>> CustomMappingsBySource { get; set; }
-        private volatile Dictionary<long, Func<object, object, object>> _customTypeMapperCache = new Dictionary<long, Func<object, object, object>>();
+        private Dictionary<long, Func<object, object, object>> _customTypeMapperCache = new Dictionary<long, Func<object, object, object>>();
         private readonly List<long> _nonGenericCollectionMappingCache = new List<long>();
 
         private static readonly Type GenericEnumerableType = typeof(IEnumerable<>);


### PR DESCRIPTION
There are multiple times plain dictionaries are looked through while being updated (possibly by multiple threads):

![image](https://user-images.githubusercontent.com/14172414/147073079-9ac01bf8-52eb-4546-a89e-8f5914c8fe37.png)

![image](https://user-images.githubusercontent.com/14172414/147072968-55b0692b-c24b-4c76-8b04-846f7b2bdd38.png)

I've switched to reference-level concurrency - make a full copy of the dictionary & add a new value there & swap references.

This is optimal as mapping calls are far more dominant in numbers than insterts.
